### PR TITLE
Drupal files directory

### DIFF
--- a/cnf/files/README.md
+++ b/cnf/files/README.md
@@ -1,0 +1,1 @@
+This is the Drupal files directory.


### PR DESCRIPTION
Add a directory for the drupal_tangler to use as the Drupal files directory. With this present, `www/sites/default/files` should be a link to `cnf/files`.
