### PR TITLE
Use .local instead of .dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_script:
 - sudo service apache2 restart
 
   # Create host and start phantomjs driver.
-- echo "127.0.0.1 skeleton.dev" | sudo tee -a /etc/hosts
+- echo "127.0.0.1 skeleton.local" | sudo tee -a /etc/hosts
 - sudo phantomjs --webdriver=8643 &>/dev/null &
 
   # MySQL database configuration

--- a/README.dist.md
+++ b/README.dist.md
@@ -15,14 +15,14 @@
 
 1. From inside the project root, run `vagrant up`
 2. You will be prompted for the administration password on your host machine. Obey.
-3. Visit `{your-project-name}.dev` in your browser of choice.
+3. Visit `{your-project-name}.local` in your browser of choice.
 
 ## How do I work on this?
 
 ------------------
 
 1. From inside the project root `vagrant ssh`
-2. Navigate to `/var/www/sites/{your-project-name}.dev`
+2. Navigate to `/var/www/sites/{your-project-name}.local`
 
 There is your project. Run `drush` commands from the `www` directory just like you would without a VB.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 2. Name your project in the `Vagrantfile` (line 6).
 3. Update the IP Address from the [next available](https://github.com/palantirnet/palantir-maker-box/wiki/Vagrant-IP-Address) and update the wiki page
 4. Make `README.dist.md` your own project's `README.md`.
-5. Run `vagrant up` and if all went well, you can visit `YOURPROJECT.dev` in your brower of choice.
+5. Run `vagrant up` and if all went well, you can visit `YOURPROJECT.local` in your brower of choice.
 6. Rename all the things (see some bash hints below, which can be run inside your project root in vagrant).
 
 Rename things the bash way:

--- a/behat.yml
+++ b/behat.yml
@@ -12,7 +12,7 @@ default:
       goutte: ~
       selenium2:
         wd_host: "http://127.0.0.1:8643/wd/hub"
-      base_url: http://skeleton.dev
+      base_url: http://skeleton.local
     Drupal\DrupalExtension:
       blackbox: ~
       api_driver: 'drupal'


### PR DESCRIPTION
Based on a [discussion on twitter](https://twitter.com/ZenDoodles/status/585818328700215296), learning [Google owns the .dev TLD](https://www.iana.org/domains/root/db/dev.html), and discovering there is a [standard defining .local](https://tools.ietf.org/html/rfc6762) for this sort of thing.
