### PR TITLE
[WIP] Fixes vagrant install of sitespeed

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,7 +20,7 @@ Vagrant.configure("2") do |config|
   path = "/var/www/sites/#{project}.local"
 
   config.vm.synced_folder ".", "/vagrant", :disabled => true
-  config.vm.synced_folder ".", path, :nfs => true#, :mount_options => ['async','nolock','noatime','nodiratime','rw','hard','intr']
+  config.vm.synced_folder ".", path, :nfs => true
   config.vm.hostname = "#{project}.local"
   config.vm.network "private_network", :auto_network => true
   config.hostmanager.enabled = true
@@ -32,6 +32,12 @@ Vagrant.configure("2") do |config|
   set -ex
 
   /opt/phantomjs --webdriver=8643 &> /dev/null &
+  ln -s /opt/phantomjs /usr/local/bin/
+
+  apt-get update; apt-get -fy install default-jre
+
+  npm install -g sitespeed.io
+
   su vagrant -c 'cd #{path} && composer install;
   cd #{path} && [[ -f .env ]] && source .env || cp env.dist .env && source env.dist && build/install.sh'
 SCRIPT

--- a/build/install.sh
+++ b/build/install.sh
@@ -3,8 +3,6 @@ set -e
 path=$(dirname "$0")
 source $path/common.sh
 
-npm install -g sitespeed.io
-
 echo "Installing Drupal minimal profile.";
 $drush si minimal --site-name=skeleton --account-name=admin --account-pass=admin
 source $path/update.sh

--- a/circle.yml
+++ b/circle.yml
@@ -23,6 +23,7 @@ dependencies:
   post:
     - source env.dist
     - build/install.sh
+    - npm install -g sitespeed.io
     - phantomjs --webdriver=8643:
         background: true
 


### PR DESCRIPTION
Vagrant box needs java to run sitespeed, sitespeed should be installed when provisioning, not when drupal is installed.

Notes:
- java needs to be installed in the box not during the provisioning- this is a hack
- there should be a package.json file with sitespeed in it rather than doing it in install
