### PR TITLE
Fixes vagrant install issues

### DIFF
--- a/build/install.sh
+++ b/build/install.sh
@@ -3,8 +3,6 @@ set -e
 path=$(dirname "$0")
 source $path/common.sh
 
-npm install -g sitespeed.io
-
 echo "Installing Drupal minimal profile.";
 $drush si minimal --site-name=skeleton --account-name=admin --account-pass=admin
 source $path/update.sh

--- a/circle.yml
+++ b/circle.yml
@@ -16,6 +16,7 @@ dependencies:
     # You will need to add this variable in the project settings in the circle
     # ci project. This needs to be configured per project.
     - composer config --global github-oauth.github.com $GITHUB_TOKEN
+    - npm install -g sitespeed.io
 
   override:
     - composer install --prefer-dist


### PR DESCRIPTION
The default vagrant box does not have java so sitespeed is not functional. Additionally the install in build/install.sh throws a permission error. This PR moves the sitespeed install to circle.yml. 

To test:
- vagrant destroy
- vagrant up

Box should provision completely
