### PR TITLE
Cache sitespeed.io on Circle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 cnf/config.yml
 cnf/settings.php
 files
+node_modules
 www
 vendor
 .env

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,9 +36,8 @@ Vagrant.configure("2") do |config|
 
   apt-get update; apt-get -fy install default-jre
 
-  npm install -g sitespeed.io
-
   su vagrant -c 'cd #{path} && composer install;
+  cd #{path} && npm install;
   cd #{path} && [[ -f .env ]] && source .env || cp env.dist .env && source env.dist && build/install.sh'
 SCRIPT
 end

--- a/circle.yml
+++ b/circle.yml
@@ -19,11 +19,11 @@ dependencies:
 
   override:
     - composer install --prefer-dist
+    - npm install
 
   post:
     - source env.dist
     - build/install.sh
-    - npm install -g sitespeed.io
     - phantomjs --webdriver=8643:
         background: true
 
@@ -34,7 +34,7 @@ dependencies:
 
 test:
   override:
-    - sitespeed.io -u http://skeleton.local --budget cnf/sitespeed/budget.json -b chrome -n 3 -r $CIRCLE_ARTIFACTS/sitespeed --suppressDomainFolder --outputFolderName test
+    - $(npm bin)/sitespeed.io -u http://skeleton.local --budget cnf/sitespeed/budget.json -b chrome -n 3 -r $CIRCLE_ARTIFACTS/sitespeed --suppressDomainFolder --outputFolderName test
     - bin/behat --strict --format=junit --out=$CIRCLE_TEST_REPORTS/behat
     # For Drupal simple tests, the following should be a starting point:
     # bin/drush en simpletest -y && bin/drush test-run TESTNAME --xml=$CIRCLE_TEST_REPORTS/simpletest

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "palantir_sitespeed_testing",
+    "description": "Install sitespeed.io for testing.",
+    "license": "proprietary",
+    "private": true,
+    "dependencies": {
+        "sitespeed.io": "*"
+    }
+}


### PR DESCRIPTION
What do you think about installing sitespeed.io locally to the project?

The major advantage here is being able to cache it on Circle--though I guess we could also be caching the ~/npm/... where it lives when it is installed globally...

This PR merges into #37, where other sitespeed changes are being discussed.
