### PR TITLE
Remove sculpin dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,14 +44,10 @@
         "behat/mink-extension": "^2.2",
         "behat/mink-goutte-driver": "^1.2",
         "composer/composer": "@dev",
-        "dflydev/embedded-composer-console": "@dev",
-        "dflydev/embedded-composer-core": "@dev",
         "drupal/console": "^0.11.3",
         "drupal/drupal-extension": "^3.1",
         "drush/drush": "^8.0",
         "palantirnet/the-vagrant": "^0.5"
-        "sculpin/sculpin": "~2.0",
-        "sculpin/sculpin-theme-composer-plugin": "dev-master as 1.0.0"
     },
     "suggest": {
         "cweagans/composer-patches": "Try ^1.0. Apply patches to packages, especially Drupal.org contrib."


### PR DESCRIPTION
... because we're moving towards replacing Sculpin with Spress.