### PR TITLE
Embed build properties in circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -31,7 +31,23 @@ dependencies:
 
 test:
   pre:
-    - vendor/bin/phing -f vendor/palantirnet/the-build/tasks/install.xml -propertyfile vendor/palantirnet/the-build/conf/build.test.properties
+    - >
+        vendor/bin/phing -f vendor/palantirnet/the-build/tasks/install.xml
+        -Dbuild.artifact_mode=symlink
+        -Dbuild.test_output=/dev/null
+        -Ddrupal.site_name=drupal-skeleton
+        -Ddrupal.profile=standard
+        -Ddrupal.modules_enable=''
+        -Ddrupal.database.database=circle_test
+        -Ddrupal.database.username=ubuntu
+        -Ddrupal.database.password=''
+        -Ddrupal.database.host=127.0.0.1
+        -Ddrupal.settings.file_public_path=sites/default/files
+        -Ddrupal.settings.file_private_path=
+        -Ddrupal.twig.debug=false
+        -Ddrupal.uri=http://drupal-skeleton.local
+        -Ddrupal.hash_salt=temporary
+        -Ddrupal.root=web
     - vendor/bin/phing build install migrate
 
   override:


### PR DESCRIPTION
Try embedding the build properties from vendor/palantirnet/the-build/conf/build.test.properties directly in the circle.yml file. This would mean that we can remove the [build properties file from the-build](https://github.com/palantirnet/the-build/blob/master/conf/build.test.properties), which would remove a dependency between the two, sort of.