### PR TITLE
geerlingguy/drupal-vm

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,6 @@ This is a template for Drupal 8 projects using the `composer create-project` com
     ```
     composer update --lock
     ```
-1. Add our Vagrant development environment:
-
-  ```
-  vendor/bin/the-vagrant-installer
-  ```
 1. Add our build scripts:
 
   ```

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ This is a template for Drupal 8 projects using the `composer create-project` com
     ```
     composer update --lock
     ```
+1. Add the project name to the drupal-vm config
+  * Edit `conf/Vagrant/config.yml`.
+  * Change the `project` from drupal-skeleton` to `PROJECTNAME`. Note: this should be a url friendly shortname. Your environment will be available at PROJECTNAME.local.
 1. Add our build scripts:
 
   ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,11 @@
+# The absolute path to the root directory of the project. Both Drupal VM and
+# the config file need to be contained within this path.
+ENV['DRUPALVM_PROJECT_ROOT'] = "#{__dir__}"
+# The relative path from the project root to the config directory where you
+# placed your config.yml file.
+ENV['DRUPALVM_CONFIG_DIR'] = "conf"
+# The relative path from the project root to the directory where Drupal VM is located.
+ENV['DRUPALVM_DIR'] = "vendor/geerlingguy/drupal-vm"
+
+# Load the real Vagrantfile
+load "#{__dir__}/#{ENV['DRUPALVM_DIR']}/Vagrantfile"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 ENV['DRUPALVM_PROJECT_ROOT'] = "#{__dir__}"
 # The relative path from the project root to the config directory where you
 # placed your config.yml file.
-ENV['DRUPALVM_CONFIG_DIR'] = "conf"
+ENV['DRUPALVM_CONFIG_DIR'] = "conf/Vagrant"
 # The relative path from the project root to the directory where Drupal VM is located.
 ENV['DRUPALVM_DIR'] = "vendor/geerlingguy/drupal-vm"
 

--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,7 @@ dependencies:
     - sed -e "s?%PROJECT_DIR%?$(pwd)?g" --in-place /etc/apache2/sites-available/default
     - sudo a2enmod rewrite
     - echo "sendmail_path=/bin/true" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-    - echo "memory_limit=256M" > ~/.phpenv/versions/$(phpenv global)/etc/conf.d/memory.ini
+    - echo "memory_limit=-1" > ~/.phpenv/versions/$(phpenv global)/etc/conf.d/memory.ini
     - sudo service apache2 restart
     # Generate a GitHub token per project and add it to the CircleCI environment variables using the web UI.
     - composer config --global github-oauth.github.com $GITHUB_TOKEN

--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,6 @@
             "url": "git@github.com:palantirnet/the-build.git"
         },
         {
-            "type": "vcs",
-            "url": "git@github.com:palantirnet/the-vagrant.git"
-        },
-        {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
         }

--- a/composer.json
+++ b/composer.json
@@ -45,8 +45,8 @@
         "drupal/console": "^0.11.3",
         "drupal/drupal-extension": "^3.1",
         "drush/drush": "^8.0",
-        "palantirnet/the-build": "^1.0",
-        "palantirnet/the-vagrant": "^1.0"
+        "geerlingguy/drupal-vm": "^3.5",
+        "palantirnet/the-build": "^1.0"
     },
     "suggest": {
         "cweagans/composer-patches": "Try ^1.0. Apply patches to packages, especially Drupal.org contrib."

--- a/conf/Vagrant/config.yml
+++ b/conf/Vagrant/config.yml
@@ -1,6 +1,7 @@
 ---
 # This file contains overrides for the default.conf.yml file included with
 # the geerlingguy/drupal-vm.
+project: "drupal-skeleton"
 
 # If you need to run multiple instances of Drupal VM, set a unique hostname,
 # machine name, and IP address for each instance.

--- a/conf/Vagrant/config.yml
+++ b/conf/Vagrant/config.yml
@@ -1,0 +1,64 @@
+---
+# This file contains overrides for the default.conf.yml file included with
+# the geerlingguy/drupal-vm.
+
+# If you need to run multiple instances of Drupal VM, set a unique hostname,
+# machine name, and IP address for each instance.
+vagrant_hostname: "{{ project }}.local"
+vagrant_machine_name: "{{ project }}"
+vagrant_ip: 0.0.0.0
+
+
+# A list of synced folders, with the keys 'local_path', 'destination', and
+# a 'type' of [nfs|rsync|smb] (leave empty for slow native shares). See
+# http://docs.drupalvm.com/en/latest/extras/syncing-folders/ for more info.
+vagrant_synced_folders:
+  # The first synced folder will be used for the default Drupal installation, if
+  # any of the build_* settings are 'true'. By default the folder is set to
+  # the drupal-vm folder.
+  - local_path: .
+    destination: "/var/www/{{ project }}.local"
+    type: nfs
+    create: true
+
+# Set 'build_makefile' to 'false' and this to 'true' if you are using a
+# composer based site deployment strategy.
+build_composer: true
+drupal_composer_path: false
+drupal_composer_install_dir: "/var/www/{{ project }}.local"
+drupal_composer_dependencies: []
+
+# Set this to 'true' and 'build_makefile', 'build_composer' to 'false' if you
+# are using Composer's create-project as a site deployment strategy.
+build_composer_project: false
+
+# Set this to 'false' if you don't need to install drupal (using the drupal_*
+# settings below), but instead copy down a database (e.g. using drush sql-sync).
+install_site: false
+
+# Required Drupal settings.
+drupal_core_path: "{{ drupal_composer_install_dir }}/web"
+drupal_db_user: drupal
+drupal_db_password: drupal
+drupal_db_name: drupal
+
+# Comment out any extra utilities you don't want to install. If you don't want
+# to install *any* extras, set this value to an empty set, e.g. `[]`.
+installed_extras:
+  - adminer
+  # - blackfire
+  - drupalconsole
+  # - elasticsearch
+  # - java
+  - mailhog
+  - memcached
+  # - newrelic
+  - nodejs
+  - pimpmylog
+  # - redis
+  # - ruby
+  # - selenium
+  - solr
+  - varnish
+  # - xdebug
+  # - xhprof


### PR DESCRIPTION
I know you wanted this on the-vagrant @becw, but in retrospect the drupal-vm is really more of a *replacement* for the-vagrant. It's not the actual box (it uses geerlingguy/ubuntu1604 by default).

### To test:
* Download [packages.json.txt](https://github.com/palantirnet/drupal-skeleton/files/658588/packages.json.txt), rename it packages.json.
* Use the [README.md]() to create a project with one exception: Use `composer create-project palantirnet/drupal-skeleton {{ project-name }} dev-drupal-vm --no-interaction --repository={{ path/to/packages.json }}` instead of the create project line in the README.md file.


