### PR TITLE
Prevent behat from caching compiled gherkin.

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -9,6 +9,8 @@ default:
         - Drupal\DrupalExtension\Context\DrushContext
       filters:
         tags: "~@skipci"
+  gherkin:
+    cache: ~
   extensions:
     Behat\MinkExtension:
       goutte: ~


### PR DESCRIPTION
This caching can prevent behat from picking up changes to tests, especially on Vagrant filesystems.

https://github.com/Behat/Gherkin/issues/97