### PR TITLE
Use Drush 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,10 @@
     },
     "repositories": [
         {
+            "type": "vcs",
+            "url": "https://github.com/becw/phing-drush-task"
+        },
+        {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
         }
@@ -37,7 +41,7 @@
         "drupal/console": "^1.0",
         "drupal/drupal-extension": "^3.1",
         "drush/drush": "9.0.0-beta7 as 8.1.15",
-        "palantirnet/the-build": "^1.0",
+        "palantirnet/the-build": "dev-use-drush-9",
         "palantirnet/the-vagrant": "^1.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "behat/mink-goutte-driver": "^1.2",
         "drupal/console": "^0.11.3",
         "drupal/drupal-extension": "^3.1",
-        "drush/drush": "^8.0",
+        "drush/drush": "9.0.0-beta7 as 8.1.15",
         "palantirnet/the-build": "^1.0",
         "palantirnet/the-vagrant": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "drupal/console": "^1.0",
         "drupal/drupal-extension": "^3.1",
         "drush/drush": "9.0.0-beta7 as 8.1.15",
-        "palantirnet/the-build": "dev-use-drush-9",
+        "palantirnet/the-build": "^2.0",
         "palantirnet/the-vagrant": "^1.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
     ],
     "require": {
         "composer/installers": "^1.0",
-        "drupal-composer/drupal-scaffold": "^1.0",
-        "drupal/config_installer": "^1.0",
+        "drupal-composer/drupal-scaffold": "^2.3",
+        "drupal/config_installer": "^1.5",
         "drupal/core": "^8.0"
     },
     "require-dev": {
@@ -34,7 +34,7 @@
         "behat/mink": "^1.7",
         "behat/mink-extension": "^2.2",
         "behat/mink-goutte-driver": "^1.2",
-        "drupal/console": "^0.11.3",
+        "drupal/console": "^1.0",
         "drupal/drupal-extension": "^3.1",
         "drush/drush": "9.0.0-beta7 as 8.1.15",
         "palantirnet/the-build": "^1.0",


### PR DESCRIPTION
## Description

Updates composer dependencies so that they are compatible with Drupal 8.4's dependencies.

Drush 8 is not compatible with Drupal 8.4 (`drupal/core:8.4.0`) -- the Drush 9 update is required. However, the `continuousphp/phing-drush-task` package declares a dependency on Drush `6.5 - 8.1`, which prevents the Drush update (and therefore the Drupal 8.4 update). To work around this, we require Drush 9 but alias the version to 8.1, so that it fulfills both the Drupal 8.4 requirements AND the `continuousphp/phing-drush-task` requirements.

I prefer this approach to using a forked repo for `continuousphp/phing-drush-task` ([weitzman](https://github.com/weitzman/phing-drush-task), [froboy](https://github.com/froboy/phing-drush-task)), since we can reference the original repository and receive updates from there once they eventually come through.

Unfortunately, Drush usage has changed significantly between Drush 8 and 9, since Drush is now built on `symfony/console`. This means that `palantirnet/the-build` and `continuousphp/phing-drush-task` needed updates too.