### PR TITLE
Changes "sort-packages" to be a boolean

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "prefer-stable": true,
     "preferred-install": "dist",
     "config": {
-        "sort-packages": "true"
+        "sort-packages": true
     },
     "repositories": [
         {


### PR DESCRIPTION
Necessary for the installer to complete, otherwise a JSON parsing error is thrown.

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
