### PR TITLE
Add the styleguide

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,5 +64,15 @@
                 ".htaccess": ".htaccess"
             }
         }
-    }    
+    },
+    "scripts": {
+        "post-create-project-cmd": [
+            "@init-styleguide"
+        ],
+        "init-styleguide": [
+            "[[ ! -d styleguide ]] && git clone git@github.com:palantirnet/palantir-lab.git styleguide || true",
+            "rm -rf styleguide/.git/",
+            "@composer install --working-dir=styleguide --ignore-platform-reqs --no-interaction"
+        ]
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         ],
         "init-styleguide": [
             "[[ ! -d styleguide ]] && git clone git@github.com:palantirnet/palantir-lab.git styleguide || true",
-            "rm -rf styleguide/.git/",
+            "rm -rf styleguide/.git/ styleguide/LICENSE",
             "@composer install --working-dir=styleguide --ignore-platform-reqs --no-interaction"
         ]
     }


### PR DESCRIPTION
This is related to [ZRAD-120](https://palantir.atlassian.net/browse/ZRAD-120) - Add base theme and style guide to palantirnet/drupal-skeleton.

The main things to consider here are:

* The drupal-skeleton is public, but the palantir-lab starter kit is not.
* The styleguide directory in the skeleton shouldn't be pinned to a particular version of the palantir-lab
* The palantir-lab starter kit shouldn't be a composer dependency, because drupal dependencies might be different than, or might conflict with, patternlab dependencies

This PR currently initializes the styleguide when the `composer create-project` command is run:

```
composer create-project palantirnet/drupal-skeleton example dev-add-default-styleguide --no-interaction
```

However, we can't merge this as-is, because of the first bullet above -- this would make the `create-project` command fail for anyone without access to our internal repos.