### PR TITLE
test PR #99 of the-build against the skeleton

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,7 @@ jobs:
               vendor/bin/phing -f vendor/palantirnet/the-build/tasks/install.xml
               -Dbuild.artifact_mode=symlink
               -Dbuild.test_output=/dev/null
+              -Dbuild.host=other
               -Ddrupal.site_name=drupal-skeleton
               -Ddrupal.profile=standard
               -Ddrupal.modules_enable=''

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,12 +106,6 @@ jobs:
               -Ddrupal.root=web
               -Dinstall_now=y
       - run:
-          name: Build Drupal's settings.php
-          command: vendor/bin/phing build
-      - run:
-          name: Install Drupal
-          command: vendor/bin/phing install
-      - run:
           name: Run Behat tests
           command: |
               nohup php -S ${CIRCLE_PROJECT_REPONAME}.local:8000 -t $(pwd)/web/ > /tmp/artifacts/phpd.log 2>&1 &

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,6 @@ jobs:
               -Ddrupal.database.password=''
               -Ddrupal.database.host=127.0.0.1
               -Ddrupal.settings.file_public_path=sites/default/files
-              -Ddrupal.settings.file_private_path=
               -Ddrupal.twig.debug=false
               -Ddrupal.uri=http://${CIRCLE_PROJECT_REPONAME}.local:8000
               -Ddrupal.hash_salt=temporary

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,7 @@ jobs:
               -Ddrupal.uri=http://${CIRCLE_PROJECT_REPONAME}.local:8000
               -Ddrupal.hash_salt=temporary
               -Ddrupal.root=web
+              -Dinstall_now=y
       - run:
           name: Build Drupal's settings.php
           command: vendor/bin/phing build

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "behat/mink-goutte-driver": "^1.2",
         "drupal/coder": "^8.0",
         "drupal/drupal-extension": "^3.1",
-        "palantirnet/the-build": "^1.7",
+        "palantirnet/the-build": "dev-clarify-drupal-build"
         "palantirnet/the-vagrant": "^2.2"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "behat/mink-goutte-driver": "^1.2",
         "drupal/coder": "^8.0",
         "drupal/drupal-extension": "^3.1",
-        "palantirnet/the-build": "dev-clarify-drupal-build"
+        "palantirnet/the-build": "dev-clarify-drupal-build",
         "palantirnet/the-vagrant": "^2.2"
     },
     "suggest": {


### PR DESCRIPTION
Run CircleCI tests on the skeleton using the updates from https://github.com/palantirnet/the-build/pull/99

Updates the `.circleci/config.yml` for testing the skeleton to work with the changes in the-build.

To do:
- [ ] revert the change to `composer.json` once the PR referenced above is merged into the-build