### PR TITLE
ZRAD-125: Composer and npm file cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,9 @@ styleguide/source/code/css/*.css
 # Ignore sculpin output
 styleguide/output_dev/
 styleguide/output_prod/
+
+# Capture styleguide lock files
+!styleguide/composer.lock
+!styleguide/package-lock.json
+!styleguide/yarn.lock
+

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "behat/mink-goutte-driver": "^1.2",
         "drupal/coder": "^8.0",
         "drupal/drupal-extension": "^3.1",
-        "palantirnet/the-build": "^1.7",
+        "palantirnet/the-build": "^1.8",
         "palantirnet/the-vagrant": "^2.2"
     },
     "suggest": {


### PR DESCRIPTION
## JIRA Ticket(s)

- See ticket [ZRAD-125: Composer and npm file cleanup](https://palantir.atlassian.net/browse/ZRAD-125).

## Description

Updates the skeleton `.gitignore` to ensure Palantir-Lab styleguide lock files are committed to the project.

## Testing instructions

- Setup a new project, according to the skeleton's Readme.
`composer create-project palantirnet/drupal-skeleton gi-test dev-zrad-125-gitignore-lock-files --no-interaction`
- `git init`
- Clone [Palantir-Lab](https://github.com/palantirnet/palantir-lab) into the `styleguide` folder.
- Run `composer install` and `yarn install` there, as per its Readme.
- `git add styleguide`
- Notice `composer.lock` and `yarn.lock` are staged to be committed.

## Additional Notes:

This PR should be merged once Pattern-Lab is being used on projects.

To get Composer to install dependencies properly, I had to require `^1.8` of the-build.  We may not want to commit that change with this PR.  If not, we should revert that change, but we will likely need to resolve that issue in a separate PR (see errors in the comments below).


---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
