### PR TITLE
Update drupal/coder version requirement to match that of the-build

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "behat/mink": "^1.7",
         "behat/mink-extension": "^2.2",
         "behat/mink-goutte-driver": "^1.2",
-        "drupal/coder": "^8.0",
+        "drupal/coder": "~8.2.12",
         "drupal/drupal-extension": "^3.1",
         "palantirnet/the-build": "^1.8",
         "palantirnet/the-vagrant": "^2.2"
@@ -65,5 +65,5 @@
                 ".htaccess": ".htaccess"
             }
         }
-    }    
+    }
 }


### PR DESCRIPTION
## Issue

- See #81 

## Description

Updates the package requirment version for `drupal/coder` to match that of the-build

## Testing instructions

1. Follow the steps in the quick start guide to start a new project using drupal-skeleton
1. Use this branch instead of drupal8: `composer create-project palantirnet/drupal-skeleton example dev-81-update-drupal-coder-package-version --no-interaction`

