### PR TITLE
83: Suggest modules in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,11 @@
         "palantirnet/the-vagrant": "^2.2"
     },
     "suggest": {
-        "cweagans/composer-patches": "Try ^1.0. Apply patches to packages, especially Drupal.org contrib."
+        "cweagans/composer-patches": "Try ^1.0. Apply patches to packages, especially Drupal.org contrib.",
+        "drupal/admin_toolbar": "Transforms the default Drupal Toolbar into a drop-down menu.",
+        "drupal/environment_indicator": "Adds a configurable color bar to each one of your environments to help identify which environment you are currently working in.",
+        "drupal/stage_file_proxy": "A solution for getting production files on a development server on demand (add to your development config_split).",
+        "drupal/twig_xdebug": "Enables use of Xdebug breakpoints with Twig templates (add to your development config_split)."
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "behat/mink": "^1.7",
         "behat/mink-extension": "^2.2",
         "behat/mink-goutte-driver": "^1.2",
-        "drupal/coder": "^8.0",
+        "drupal/coder": "~8.2.12",
         "drupal/drupal-extension": "^3.1",
         "palantirnet/the-build": "^1.8",
         "palantirnet/the-vagrant": "^2.2"
@@ -65,5 +65,5 @@
                 ".htaccess": ".htaccess"
             }
         }
-    }    
+    }
 }


### PR DESCRIPTION
## Issue

- See #83 

## Description

Adds a few modules as suggestions in composer.json to help improve the local development experience.

## Testing instructions

1. See suggestions in composer.json: https://github.com/palantirnet/drupal-skeleton/pull/84/commits/8142dcb6f258f4a03702bd6d0f078914e20f5e5f

Note: This branch also (inadvertantly) contains the commit for #82 which addresses #81 -- happy to revert the commit if necessary.