### PR TITLE
Update composer.json for Drupal 8.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ styleguide/output_prod/
 !styleguide/package-lock.json
 !styleguide/yarn.lock
 
+.editorconfig
+.gitattributes

--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,10 @@
     ],
     "require": {
         "composer/installers": "^1.0",
-        "drupal-composer/drupal-scaffold": "^2.5.0",
+        "drupal/core-composer-scaffold": "^8.8",
         "drupal/config_installer": "^1.8",
         "drupal/config_split": "^1.4",
-        "drupal/core": "^8.0@stable",
+        "drupal/core-recommended": "^8.7.0",
         "zaporylie/composer-drupal-optimizations": "^1.1"
     },
     "require-dev": {
@@ -39,6 +39,7 @@
         "behat/mink-extension": "^2.2",
         "behat/mink-goutte-driver": "^1.2",
         "drupal/coder": "~8.2.12",
+        "drupal/core-dev": "^8.7.0",
         "drupal/drupal-extension": "^3.1",
         "palantirnet/the-build": "^2.0",
         "palantirnet/the-vagrant": "^2.3"
@@ -62,11 +63,18 @@
             "drush/contrib/{$name}": ["type:drupal-drush"]
         },
         "drupal-scaffold": {
-            "excludes": [
-                ".htaccess"
+            "allowed-packages": [
+                "drupal/core"
             ],
-            "initial": {
-                ".htaccess": ".htaccess"
+            "locations": {
+                "web-root": "web/"
+            },
+            "file-mapping": {
+                "[web-root]/.htaccess": {
+                    "mode": "replace",
+                    "path": "assets/scaffold/files/htaccess",
+                    "overwrite": false
+                }
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
             "file-mapping": {
                 "[web-root]/.htaccess": {
                     "mode": "replace",
-                    "path": "assets/scaffold/files/htaccess",
+                    "path": "web/core/assets/scaffold/files/htaccess",
                     "overwrite": false
                 }
             }


### PR DESCRIPTION
Updates the composer.json to use the new `drupal/core-composer-scaffold` package.

@see [slides from Drupalcon Amsterdam](https://docs.google.com/presentation/d/1jYMI_w-e8QYs0uJLtB5PIkD4RI1hGja9OUPmRTnEKRk/edit#slide=id.g649f8d6087_2_352) and the [drupal/core-composer-scaffold README](https://github.com/drupal/core-composer-scaffold#altering-scaffold-files).

This new scaffolding tool doesn't allow you to manage scaffolding files from your dependencies beyond saying "yes", "no", or "append". So, for the .htaccess file, which we want Drupal core to install but not update, we have to reference its full path as if it belongs to our project.

There's a Drupal core issue on the scaffolding behavior, which allows Drupal core to predictably handle user modifications to scaffolded files: https://www.drupal.org/project/drupal/issues/3092563. It looks like this fix will NOT be included in the 8.8.0 release, which means that we should manage the `.htaccess` file ourselves for the time being.