### PR TITLE
Composer cleanup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
         "zaporylie/composer-drupal-optimizations": "^1.1"
     },
     "require-dev": {
-        "drupal/coder": "~8.2.12",
         "drupal/core-dev": "^8.7.0",
         "drupal/drupal-extension": "^3.1",
         "palantirnet/the-build": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -34,10 +34,6 @@
         "zaporylie/composer-drupal-optimizations": "^1.1"
     },
     "require-dev": {
-        "behat/behat": "^3.1",
-        "behat/mink": "^1.7",
-        "behat/mink-extension": "^2.2",
-        "behat/mink-goutte-driver": "^1.2",
         "drupal/coder": "~8.2.12",
         "drupal/core-dev": "^8.7.0",
         "drupal/drupal-extension": "^3.1",


### PR DESCRIPTION
Remove dependencies from the root `composer.json` that are handled by/dependencies of other dependencies. The drupal-skeleton has no direct dependency on these things.