### PR TITLE
8.8 fine tuning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
         "drupal/config_installer": "^1.8",
         "drupal/config_split": "^1.4",
         "drupal/core-composer-scaffold": "^8.8",
-        "drupal/core-project-message": "^8.8",
         "drupal/core-recommended": "^8.8",
         "zaporylie/composer-drupal-optimizations": "^1.1"
     },
@@ -75,15 +74,6 @@
             "drush/Commands/contrib/{$name}": ["type:drupal-drush"],
             "web/modules/custom/{$name}": ["type:drupal-custom-module"],
             "web/themes/custom/{$name}": ["type:drupal-custom-theme"]
-        },
-        "drupal-core-project-message": {
-            "post-create-project-cmd-message": [
-                "<bg=blue;fg=white>                                                         </>",
-                "<bg=blue;fg=white>  Congratulations, you’ve installed the Drupal codebase  </>",
-                "<bg=blue;fg=white>  from the drupal/recommended-project template!          </>",
-                "<bg=blue;fg=white>                                                         </>",
-                ""
-            ]
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     ],
     "require": {
         "composer/installers": "^1.2",
-        "drupal/coder": "^8.3.6",
         "drupal/config_installer": "^1.8",
         "drupal/config_split": "^1.4",
         "drupal/core-composer-scaffold": "^8.8",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require-dev": {
         "drupal/core-dev": "^8.8",
         "drupal/drupal-extension": "^3.1",
-        "palantirnet/the-build": "dev-8.8-fine-tuning",
+        "palantirnet/the-build": "^2.2.1",
         "palantirnet/the-vagrant": "^2.3"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -8,17 +8,6 @@
             "email": "info@palantir.net"
         }
     ],
-    "minimum-stability": "dev",
-    "prefer-stable": true,
-    "config": {
-        "platform": {
-            "php": "7.2"
-        },
-        "preferred-install": {
-            "*": "dist"
-        },
-        "sort-packages": true
-    },
     "repositories": [
         {
             "type": "composer",
@@ -26,15 +15,17 @@
         }
     ],
     "require": {
-        "composer/installers": "^1.0",
-        "drupal/core-composer-scaffold": "^8.8",
+        "composer/installers": "^1.2",
         "drupal/config_installer": "^1.8",
         "drupal/config_split": "^1.4",
-        "drupal/core-recommended": "^8.7.0",
+        "drupal/core-composer-scaffold": "^8.8",
+        "drupal/core-project-message": "^8.8",
+        "drupal/core-recommended": "^8.8",
+	"drupal/coder": "^8.3.6",
         "zaporylie/composer-drupal-optimizations": "^1.1"
     },
     "require-dev": {
-        "drupal/core-dev": "^8.7.0",
+        "drupal/core-dev": "^8.8",
         "drupal/drupal-extension": "^3.1",
         "palantirnet/the-build": "^2.0",
         "palantirnet/the-vagrant": "^2.3"
@@ -49,21 +40,25 @@
     "conflict": {
         "drupal/drupal": "*"
     },
-    "extra": {
-        "installer-paths": {
-            "web/core": ["type:drupal-core"],
-            "web/modules/contrib/{$name}": ["type:drupal-module"],
-            "web/profiles/contrib/{$name}": ["type:drupal-profile"],
-            "web/themes/contrib/{$name}": ["type:drupal-theme"],
-            "drush/contrib/{$name}": ["type:drupal-drush"]
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "config": {
+        "platform": {
+            "php": "7.3"
         },
+        "preferred-install": {
+            "*": "dist"
+        },
+        "sort-packages": true
+    },
+    "extra": {
         "drupal-scaffold": {
-            "allowed-packages": [
-                "drupal/core"
-            ],
             "locations": {
                 "web-root": "web/"
             },
+            "allowed-packages": [
+                "drupal/core"
+            ],
             "file-mapping": {
                 "[web-root]/.htaccess": {
                     "mode": "replace",
@@ -71,6 +66,26 @@
                     "overwrite": false
                 }
             }
+        },
+        "installer-paths": {
+            "web/core": ["type:drupal-core"],
+            "web/libraries/{$name}": ["type:drupal-library"],
+            "web/modules/contrib/{$name}": ["type:drupal-module"],
+            "web/profiles/contrib/{$name}": ["type:drupal-profile"],
+            "web/themes/contrib/{$name}": ["type:drupal-theme"],
+            "drush/Commands/contrib/{$name}": ["type:drupal-drush"],
+            "web/modules/custom/{$name}": ["type:drupal-custom-module"],
+            "web/themes/custom/{$name}": ["type:drupal-custom-theme"]
+        },
+        "drupal-core-project-message": {
+            "include-keys": ["homepage", "support"],
+            "post-create-project-cmd-message": [
+                "<bg=blue;fg=white>                                                         </>",
+                "<bg=blue;fg=white>  Congratulations, you’ve installed the Drupal codebase  </>",
+                "<bg=blue;fg=white>  from the drupal/recommended-project template!          </>",
+                "<bg=blue;fg=white>                                                         </>",
+                ""
+            ]
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,18 +16,18 @@
     ],
     "require": {
         "composer/installers": "^1.2",
+        "drupal/coder": "^8.3.6",
         "drupal/config_installer": "^1.8",
         "drupal/config_split": "^1.4",
         "drupal/core-composer-scaffold": "^8.8",
         "drupal/core-project-message": "^8.8",
         "drupal/core-recommended": "^8.8",
-	"drupal/coder": "^8.3.6",
         "zaporylie/composer-drupal-optimizations": "^1.1"
     },
     "require-dev": {
         "drupal/core-dev": "^8.8",
         "drupal/drupal-extension": "^3.1",
-        "palantirnet/the-build": "^2.0",
+        "palantirnet/the-build": "dev-8.8-fine-tuning",
         "palantirnet/the-vagrant": "^2.3"
     },
     "suggest": {
@@ -78,7 +78,6 @@
             "web/themes/custom/{$name}": ["type:drupal-custom-theme"]
         },
         "drupal-core-project-message": {
-            "include-keys": ["homepage", "support"],
             "post-create-project-cmd-message": [
                 "<bg=blue;fg=white>                                                         </>",
                 "<bg=blue;fg=white>  Congratulations, you’ve installed the Drupal codebase  </>",


### PR DESCRIPTION
## Description

Based on Drupal core's [new composer template](https://www.drupal.org/node/3082474), I updated `composer.json` to follow a similar structure.

## Testing instructions

1. `composer install`

## Remaining tasks

- [ ] After [the-build PR](https://github.com/palantirnet/the-build/pull/143) gets merged with the new version of coder, update `composer.json` here to use `the-build`'s new release version instead of using `the-build` special temporary branch.
