### PR TITLE
update to drupal 9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     working_directory: ~/drupal-skeleton
     docker:
-      - image: circleci/php:7.2-node-browsers
+      - image: circleci/php:7.3-node-browsers
       - image: circleci/mysql:5.7-ram
         command: --max_allowed_packet=16M
         environment:

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "drupal/core-dev": "^9",
         "drupal/drupal-extension": "^4.1.0",
-        "palantirnet/the-build": "^2.2.1",
+        "palantirnet/the-build": "dev-drupal9",
         "palantirnet/the-vagrant": "^2.3"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     ],
     "require": {
         "composer/installers": "^1.2",
-        "drupal/config_installer": "^1.8",
         "drupal/config_split": "^1.4",
         "drupal/core-composer-scaffold": "^9",
         "drupal/core-recommended": "^9",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "drupal/core-dev": "^9",
-        "drupal/drupal-extension": "^3.1",
+        "drupal/drupal-extension": "^4.1.0",
         "palantirnet/the-build": "^2.2.1",
         "palantirnet/the-vagrant": "^2.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
         "composer/installers": "^1.2",
         "drupal/config_installer": "^1.8",
         "drupal/config_split": "^1.4",
-        "drupal/core-composer-scaffold": "^8.8",
-        "drupal/core-recommended": "^8.8",
+        "drupal/core-composer-scaffold": "^9",
+        "drupal/core-recommended": "^9",
         "zaporylie/composer-drupal-optimizations": "^1.1"
     },
     "require-dev": {
-        "drupal/core-dev": "^8.8",
+        "drupal/core-dev": "^9",
         "drupal/drupal-extension": "^3.1",
         "palantirnet/the-build": "^2.2.1",
         "palantirnet/the-vagrant": "^2.3"


### PR DESCRIPTION
## Description

- Updates `composer.json` to use Drupal 9.
- Removes [Config Installer](https://www.drupal.org/project/config_installer), since there will be no D9 version.
- Updates Drupal Extension to 4.1.0 for Symfony 4 support.

## Testing instructions

- `composer create-project palantirnet/drupal-skeleton drupal9 dev-drupal9 --no-interaction`
- Use the `drupal9` branch of The Build for D9 compatibility updates. In `composer.json`:
```
        "palantirnet/the-build": "dev-drupal9",
```
- `composer update palantirnet/the-build`
- Continue with the setup instructions in the [Readme](https://github.com/palantirnet/drupal-skeleton/blob/develop/README.md).

Note: After review and testing, change the version of `the-build` in `composer.json` back to its previous value before merging. See https://github.com/palantirnet/drupal-skeleton/pull/111/commits/fb9571eeb3838b766828ba511683109ec4219117