### PR TITLE
Update composer.json dependencies to support composer2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,10 @@
         }
     ],
     "require": {
-        "composer/installers": "^1.2",
+        "composer/installers": "^1.9",
         "drupal/config_split": "^1.4",
         "drupal/core-composer-scaffold": "^9",
-        "drupal/core-recommended": "^9",
-        "zaporylie/composer-drupal-optimizations": "^1.1.2"
+        "drupal/core-recommended": "^9"
     },
     "require-dev": {
         "drupal/core-dev": "^9",
@@ -28,7 +27,7 @@
         "palantirnet/the-vagrant": "^2.3"
     },
     "suggest": {
-        "cweagans/composer-patches": "Try ^1.0. Apply patches to packages, especially Drupal.org contrib.",
+        "cweagans/composer-patches": "Try ^1.7. Apply patches to packages, especially Drupal.org contrib.",
         "drupal/admin_toolbar": "Transforms the default Drupal Toolbar into a drop-down menu.",
         "drupal/environment_indicator": "Adds a configurable color bar to each one of your environments to help identify which environment you are currently working in.",
         "drupal/config_ignore": "Exclude configuration to be exported to the configuration set.",


### PR DESCRIPTION
### Description

Update `composer.json` dependencies to fully support composer 2.
### Testing instructions

1. Get rid of any files that are not in the repo `git clean -fdx`
1. Make sure you are running composer 2 by running `composer self-update --2`
1. Run composer install

### Open questions

_Delete this section if there are no open questions._

* What questions are blocking this work?

### Remaining tasks

_Delete this section if there are no remaining tasks._

- [ ] Update the README
