### PR TITLE
Update devel module to 4.1.x for D9 support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "drupal/config_split": "^1.7",
         "drupal/core-composer-scaffold": "^9",
         "drupal/core-recommended": "^9",
-        "drupal/devel": "^3.0@dev",
+        "drupal/devel": "^4.1",
         "drupal/workbench": "^1.3",
         "drupal/workbench_tabs": "^1.5"
     },


### PR DESCRIPTION
User story: [ABC-XX: Story name](https://palantir.atlassian.net/browse/ABC-XX)

### Description

When running through the install steps of the README, the install fails due to a Devel module dependency issue. For Drupal 9 support Devel needs to be updated to 4.0.x, so I went ahead and updated to 4.1.x in this PR.

### Testing instructions

1. Run through the install steps noted in this repo's README; however, for step 1 instead use this command `composer create-project palantirnet/drupal-skeleton example dev-update-devel-for-d9 --no-interaction`.
2. BEFORE running the install step, require the test version of `the-build` by running `comp require palantirnet/the-build:dev-update-devel-for-d9`, which will use the updated target from https://github.com/palantirnet/the-build/pull/176.
2. Confirm that site installs and loads correctly.