### PR TITLE
WIP: Enable Composer patches from dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require-dev": {
         "drupal/core-dev": "^9",
         "drupal/drupal-extension": "^4.1.0",
-        "palantirnet/the-build": "^4@alpha"
+        "palantirnet/the-build": "dev-detect-ddev-byron"
     },
     "suggest": {
         "cweagans/composer-patches": "Try ^1.7. Apply patches to packages, especially Drupal.org contrib.",
@@ -76,6 +76,7 @@
             "drush/Commands/contrib/{$name}": ["type:drupal-drush"],
             "docroot/modules/custom/{$name}": ["type:drupal-custom-module"],
             "docroot/themes/custom/{$name}": ["type:drupal-custom-theme"]
-        }
+        },
+        "enable-patching": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require-dev": {
         "drupal/core-dev": "^9",
         "drupal/drupal-extension": "^4.1.0",
-        "palantirnet/the-build": "dev-detect-ddev-byron"
+        "palantirnet/the-build": "^4@alpha"
     },
     "suggest": {
         "cweagans/composer-patches": "Try ^1.7. Apply patches to packages, especially Drupal.org contrib.",


### PR DESCRIPTION
### Description

Updates `composer.json` to allow patches to be applied from dependencies.

This PR temporarily changes the version constraint of `palantirnet/the-build` to test a branch that contains a patch for Phing. That change should be reverted before this PR is merged.

### Testing instructions

* `composer create-project palantirnet/drupal-skeleton example dev-composer-patches-dependencies --no-interaction`
* Verify the patch for Phing is installed (included in the `detect-ddev-byron` branch).

### Open questions

* Should we remove `cweagans/composer-patches` from the `"suggest": { }` section if `the-build` requires it? See https://github.com/palantirnet/the-build/pull/179.

### Remaining tasks

- [ ] Revert the changed version constraint of `the-build` after testing.
