### PR TITLE
Adds additional Composer patching configuration.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,6 +77,10 @@
             "docroot/modules/custom/{$name}": ["type:drupal-custom-module"],
             "docroot/themes/custom/{$name}": ["type:drupal-custom-theme"]
         },
-        "enable-patching": true
+        "enable-patching": true,
+        "composer-exit-on-patch-failure": true,
+        "patchLevel": {
+            "drupal/core": "-p2"
+        }
     }
 }


### PR DESCRIPTION
User story: N/A

### Description

- Adds some additional patching configuration above and beyond what was added in https://github.com/palantirnet/drupal-skeleton/pull/121.
- Additional configuration will force Composer to exit when a patch fails to apply, and will also ensure that Drupal Core is properly patched at the appropriate nesting level.

### Testing instructions

1. Run `composer create-project palantirnet/drupal-skeleton example dev-add-additional-patching-config --no-interaction`.
2. Ensure that the project installed properly with no errors.