### PR TITLE
Add the allow-plugins composer configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,11 @@
     "minimum-stability": "stable",
     "prefer-stable": true,
     "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "drupal/core-composer-scaffold": true,
+            "cweagans/composer-patches": true
+        },
         "platform": {
             "php": "7.4"
         },


### PR DESCRIPTION
Add the allow-plugins composer configuration (https://getcomposer.org/doc/06-config.md#allow-plugins)

### Testing instructions

1. Update to Composer 2.2 or greater (`composer self-update`)
2. Run `composer install` in the drupal-skeleton
3. You should **not** be prompted to allow composer plugins (e.g. "Do you trust "composer/installers" to execute code and wish to enable it now?")