### PR TITLE
Update to latest composer on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,9 @@ jobs:
       - run:
           name: Configure URL in /etc/hosts
           command: echo 127.0.0.1 ${CIRCLE_PROJECT_REPONAME}.local | sudo tee -a /etc/hosts
+      - run:
+          name: Update to latest version of Composer
+          command: sudo composer self-update
 
       # Note: phing and drupal-check have mutually exclusive requirements.
       # It'd be better to add drupal-check as a dependency of the drupal project


### PR DESCRIPTION
### Description

The latest release of https://github.com/palantirnet/the-build will not install when using Composer 2.1.x. This adds a step to the CircleCI config to self-update Composer before installing dependencies.

### Testing instructions

* Verify tests pass on circle.
* Verify Composer installs `4.0-alpha7` or later on CircleCI.

<img width="589" alt="image" src="https://user-images.githubusercontent.com/767994/160469366-892a6193-c663-4c39-a11b-b3bb7863c089.png">
<img width="583" alt="image" src="https://user-images.githubusercontent.com/767994/160469513-84144413-2e8a-4ed6-9322-5628cb3f512c.png">
