### PR TITLE
Remove the upper bound version constraint on drupal/devel.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "drupal/config_split": "^1.7",
         "drupal/core-composer-scaffold": "^9",
         "drupal/core-recommended": "^9",
-        "drupal/devel": "^4.1",
+        "drupal/devel": ">=4.1",
         "drupal/workbench": "^1.3",
         "drupal/workbench_tabs": "^1.5"
     },


### PR DESCRIPTION
Allows installing devel 5, and beyond!