### PR TITLE
Move dev caching settings to settings.local.php and services.local.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ web/sites/*/files
 docroot/sites/*/files
 
 # Ignore local Drupal configuration
+services.local.yml
 settings.local.php
 settings.ddev.php
 

--- a/docroot/sites/default/default.services.local.yml
+++ b/docroot/sites/default/default.services.local.yml
@@ -1,7 +1,7 @@
 # @file
 # Local development services.
 #
-# Copy this file to 'local.services.yml' and customize for your development needs.
+# Copy this file to 'services.local.yml' and customize for your development needs.
 
 services:
   cache.backend.null:

--- a/docroot/sites/default/default.services.local.yml
+++ b/docroot/sites/default/default.services.local.yml
@@ -1,0 +1,17 @@
+# @file
+# Local development services.
+#
+# Copy this file to 'local.services.yml' and customize for your development needs.
+
+services:
+  cache.backend.null:
+    class: Drupal\Core\Cache\NullBackendFactory
+parameters:
+  # The debug cacheability header can get very long and cause HTTP 500 errors. If this
+  # happens on your site, change this to false.
+  http.response.debug_cacheability_headers: true
+  twig.config:
+    debug: true
+    auto_reload: true
+    # This is important if you're using interactive debugging with Twig templates.
+    cache: true

--- a/docroot/sites/default/default.settings.local.php
+++ b/docroot/sites/default/default.settings.local.php
@@ -7,9 +7,10 @@
  * Copy this file to 'settings.local.php' and customize for your development needs.
  */
 
-// To simulate other config split environments, uncomment these split lines, then run:
+// To simulate other config split environments, uncomment and edit these lines, then run:
 //   drush cr && drush cim -y
 # $config['config_split.config_split.development']['status'] = FALSE;
+# $config['config_split.config_split.test']['status'] = FALSE;
 # $config['config_split.config_split.production']['status'] = TRUE;
 
 // Customizable development services file.

--- a/docroot/sites/default/default.settings.local.php
+++ b/docroot/sites/default/default.settings.local.php
@@ -7,7 +7,19 @@
  * Copy this file to 'settings.local.php' and customize for your development needs.
  */
 
-// To simulate other config split environments, change "development" to either "staging"
-// or "production", then run:
+// To simulate other config split environments, uncomment these split lines, then run:
 //   drush cr && drush cim -y
-# $config['config_split.config_split.development']['status'] = TRUE;
+# $config['config_split.config_split.development']['status'] = FALSE;
+# $config['config_split.config_split.production']['status'] = TRUE;
+
+// Customizable development services file.
+$settings['container_yamls'][] = DRUPAL_ROOT . '/' . $site_path . '/services.local.yml';
+
+// Disable caching.
+$settings['cache']['bins']['render'] = 'cache.backend.null';
+$settings['cache']['bins']['page'] = 'cache.backend.null';
+$settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
+
+// Disable CSS and JS aggregation.
+$config['system.performance']['css']['preprocess'] = FALSE;
+$config['system.performance']['js']['preprocess'] = FALSE;

--- a/docroot/sites/default/settings.ddev-overrides.php
+++ b/docroot/sites/default/settings.ddev-overrides.php
@@ -20,20 +20,11 @@ use Drupal\Component\Assertion\Handle;
 assert_options(ASSERT_ACTIVE, TRUE);
 Handle::register();
 
-// Enable local development services.
+// Enable local development services, including the null cache backend.
 $settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml';
 
 // Show all error messages, with backtrace information.
 $config['system.logging']['error_level'] = 'verbose';
-
-// Disable caching.
-$settings['cache']['bins']['render'] = 'cache.backend.null';
-$settings['cache']['bins']['page'] = 'cache.backend.null';
-$settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
-
-// Disable CSS and JS aggregation.
-$config['system.performance']['css']['preprocess'] = FALSE;
-$config['system.performance']['js']['preprocess'] = FALSE;
 
 // Allow test modules and themes to be installed.
 $settings['extension_discovery_scan_tests'] = FALSE;


### PR DESCRIPTION
Move dev caching settings to `settings.local.php` and `services.local.yml` to make them easier to turn on and off.

On wisdhs-workweb, we found it difficult to test caching locally because we had to dig around for the appropriate settings to mess with to have local be configured like prod. This moves those settings into local specific config files, so that devs can enable/disable easily.