### PR TITLE
add missing slash in settings.php include

### DIFF
--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -89,7 +89,7 @@ if (getenv('AH_SITE_GROUP') && file_exists(__DIR__ . '/settings.acquia.php')) {
 // Pantheon
 if (getenv('PANTHEON_ENVIRONMENT') && file_exists(__DIR__ . '/settings.pantheon.php')) {
   include __DIR__ . '/settings.pantheon-custom.php';
-  include __DIR__ . 'settings.pantheon.php';
+  include __DIR__ . '/settings.pantheon.php';
 }
 
 // Platform.sh


### PR DESCRIPTION
The include for `settings.pantheon.php` in the `settings.php` file is missing a slash which results in the following error when deploying to Pantheon:

`Warning: include(/code/web/sites/defaultsettings.pantheon.php): Failed to open stream: No such file or directory in /code/web/sites/default/settings.php on line 92 Warning: include(): Failed opening '/code/web/sites/defaultsettings.pantheon.php' for inclusion (include_path='/code/vendor/pear/pear_exception:/code/vendor/pear/console_getopt:/code/vendor/pear/pear-core-minimal/src:/code/vendor/pear/archive_tar:.:/usr/share/pear:/usr/share/php') in /code/web/sites/default/settings.php on line 92`