### PR TITLE
Add config ignore module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev": {
         "drupal/core-dev": "^9",
         "drupal/drupal-extension": "^4.1.0",
-        "palantirnet/the-build": "^4@alpha"
+        "palantirnet/the-build": "dev-add-config-ignore-module"
     },
     "suggest": {
         "cweagans/composer-patches": "Try ^1.7. Apply patches to packages, especially Drupal.org contrib.",

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require": {
         "composer/installers": "^1.9",
         "drupal/admin_toolbar": "^3.0",
+        "drupal/config_ignore": "^2.3",
         "drupal/config_split": "^1.7",
         "drupal/core-composer-scaffold": "^9",
         "drupal/core-recommended": "^9",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev": {
         "drupal/core-dev": "^9",
         "drupal/drupal-extension": "^4.1.0",
-        "palantirnet/the-build": "dev-add-config-ignore-module"
+        "palantirnet/the-build": "^4@alpha"
     },
     "suggest": {
         "cweagans/composer-patches": "Try ^1.7. Apply patches to packages, especially Drupal.org contrib.",


### PR DESCRIPTION
User story: [TECH-8: Add the config_ignore module by default](https://palantir.atlassian.net/browse/TECH-8)

### Description
Add config_ignore module to composer.json.

### Testing instructions

1. check out `add-config-ignore-module` branch.
2. Make sure config_ignore module added.
