### PR TITLE
TECH-58 Update config ignore to the dev release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require": {
         "composer/installers": "^2.0",
         "drupal/admin_toolbar": "^3",
+        "drupal/config_ignore": "2.x-dev",
         "drupal/config_split": "^1",
         "drupal/core-composer-scaffold": "^10",
         "drupal/core-recommended": "^10",


### PR DESCRIPTION
User story: [TECH-58: Triage Config Ignore for Drupal 10](https://palantir.atlassian.net/browse/TECH-58)

### Description

Add the dev release of the config ignore module so it is compatible with d10.

### Testing instructions

1. do a composer install, if you have a lock file you may also need to update dependencies
2. build the site (instructions in the readme)
3. configure config ignore /admin/config/development/configuration/ignore
4. export the config
5. observe that the config you set to be ignored is not exported.
