### PR TITLE
Temporarily change minimum-stability to dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "conflict": {
         "drupal/drupal": "*"
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
### Description

Set minimum-stability to "dev" to allow the Drupal 10 compatible version of Config Ignore to be installed by `drupal-first-install` in `the-build`.

### Testing instructions

* `composer create-project palantirnet/drupal-skeleton example dev-minimum-stability-dev --no-interaction`
* `cd example`
* `vendor/bin/the-build-installer`
* Choose `y` when prompted to install Drupal.
* Verify Composer is able to install Config Ignore 2.x-dev, and the installation completes without errors.

### Open questions

* Do we really want to do this? Or, should we instead update `the-build` to temporarily remove Config Ignore from the list of modules installed by `drupal-first-install` until there is a stable release?
