### PR TITLE
Adjust hosting provider drupal/php settings include order

### DIFF
--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -82,8 +82,8 @@ if (getenv('CIRCLECI') == 'true' && file_exists(__DIR__ . '/settings.circleci.ph
 
 // Acquia
 if (getenv('AH_SITE_GROUP') && file_exists(__DIR__ . '/settings.acquia.php')) {
-  include __DIR__ . '/settings.acquia-custom.php';
   include __DIR__ . '/settings.acquia.php';
+  include __DIR__ . '/settings.acquia-custom.php';
 }
 
 // Pantheon

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -94,8 +94,8 @@ if (getenv('PANTHEON_ENVIRONMENT') && file_exists(__DIR__ . '/settings.pantheon.
 
 // Platform.sh
 if (getenv('PLATFORM_APPLICATION') && file_exists(__DIR__ . '/settings.platform.php')) {
-  include __DIR__ . '/settings.platform-custom.php';
   include __DIR__ . '/settings.platform.php';
+  include __DIR__ . '/settings.platform-custom.php';
 }
 
 /**

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -88,8 +88,8 @@ if (getenv('AH_SITE_GROUP') && file_exists(__DIR__ . '/settings.acquia.php')) {
 
 // Pantheon
 if (getenv('PANTHEON_ENVIRONMENT') && file_exists(__DIR__ . '/settings.pantheon.php')) {
-  include __DIR__ . '/settings.pantheon-custom.php';
   include __DIR__ . '/settings.pantheon.php';
+  include __DIR__ . '/settings.pantheon-custom.php';
 }
 
 // Platform.sh


### PR DESCRIPTION
### Description

This PR updates the settings.php file to reverse the include order of the hosting provider boilerplate settings and project-specific settings.

Context from [slack conversation](https://palantirnet.slack.com/archives/CCVCR9W3A/p1673885547028489):
> On DHS we implemented memcache per Acquia Cloud’s documentation (it’s a bit different than what was in the version of the-build that we used as we spun up the project).  
> 
> Here’s the change we needed to make to include a new memcache settings file: https://github.com/palantirnet/wisdhs-public/pull/297/files#diff-208032be2366940b330741b39e4f3ce6b7535d00732cb82449d581df957c59f4
>
> We recently learned that the memcache include needed to come after the standard Acquia settings line which is in the `settings.acquia.php`  which is included after `settings.acquia-custom.php` in our `settings.php` file.

#### Notes on Hosting Platform recommendations 

From Byron:

Acquia: https://docs.acquia.com/cloud-platform/manage/code/require-line/
> Any modifications made to the settings.php file should be placed after this require line. Modifications made before the require line may be overridden by Acquia’s required file.

It seems like that aligns with including overrides after the settings files provided by each platform.

And, there's this for Pantheon which doesn't say anything about the order, just that it should always be included:
https://github.com/pantheon-systems/drops-8/blob/default/sites/default/settings.php#L8-L17

Pantheon docs: https://pantheon.io/docs/guides/php/settings-php#drupal-9

From Jes:

Similar to Pantheon, Platform.sh mentions adding custom settings to their settings file (which needs to be included) but nothing about the order: https://docs.platform.sh/guides/drupal9/deploy/customize.html#settingsphp

> If you add additional services to your application, such as Solr, Elasticsearch, or RabbitMQ, you would add configuration for those services to the `settings.platformsh.php` file as well.

### Testing instructions

Jes can validate that making this change in the DHS project codebases fixed the memcache setup. Prior to this change, Drupal was reporting memcache versions and no errors but New Relic was not showing any memcache resourcing being used.

1. _Add your testing instructions here, for example..._
1. `phing install migrate`

### Open questions

_Delete this section if there are no open questions._

* What questions are blocking this work?

### Remaining tasks

_Delete this section if there are no remaining tasks._

- [ ] Update the README
