### PR TITLE
DEV-47: Update to PHP 8.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     working_directory: ~/drupal-skeleton
     docker:
-      - image: cimg/php:8.1-browsers
+      - image: cimg/php:8.2-browsers
       - image: cimg/mysql:5.7
         command: --max_allowed_packet=16M
         environment:

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -17,7 +17,7 @@ webserver_type: apache-fpm
 #mariadb_version: "10.3"
 
 # TODO: Make sure this PHP version matches the project's hosting environment.
-php_version: "8.1"
+php_version: "8.2"
 
 # Add any multisite subdomains to this array. Adding "example" will make this environment
 # available at "example.ddev.site".

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You should have the development dependencies installed on your Mac before you be
 
 The development dependencies are:
 
-* PHP 8.1+
+* PHP 8.2+
   * Check your PHP version from the command line using `php --version`
   * If your project cannot support PHP 8.2, you should use PHP 8.1.18.
 * [XCode](https://itunes.apple.com/us/app/xcode/id497799835?mt=12)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The development dependencies are:
 
 * PHP 8.1+
   * Check your PHP version from the command line using `php --version`
+  * If your project cannot support PHP 8.2, you should use PHP 8.1.18.
 * [XCode](https://itunes.apple.com/us/app/xcode/id497799835?mt=12)
 * [Composer](https://getcomposer.org/download/)
 * [Docker](https://www.docker.com/)
@@ -36,12 +37,12 @@ Enter a short name for your project [example] :
   ```
   composer create-project palantirnet/drupal-skeleton example dev-develop --no-interaction
   ```
-  
+
   This skeleton is based on Drupal 10. If you would like to install and use Drupal 9 instead, run:
   ```
   composer create-project palantirnet/drupal-skeleton example dev-drupal9 --no-interaction
   ```
-  
+
 2. Go into your new project directory and update the ddev configuration in `.ddev/config.yml`:
 
   ```
@@ -52,7 +53,7 @@ Enter a short name for your project [example] :
   # Use 'docroot' for Acquia, or 'web' for Pantheon or Platform.sh.
   docroot: web
   ```
-  
+
 3. From inside the ddev environment, run the script from `palantirnet/the-build` to set up the default Drupal variables and install Drupal:
 
   ```
@@ -105,7 +106,7 @@ Update the `README`:
 
 Project-specific documentation at [docs/technical_approach.md](docs/technical_approach.md)
 
-  * Add `deployment.md` for deployment instructions  
+  * Add `deployment.md` for deployment instructions
 
 Update the `LICENSE.txt`:
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ The development dependencies are:
 
 * PHP 8.2+
   * Check your PHP version from the command line using `php --version`
-  * If your project cannot support PHP 8.2, you should use PHP 8.1.18.
 * Mac only: [XCode command line tools](https://mac.install.guide/commandlinetools/3)
 * [Composer](https://getcomposer.org/download/)
 * [Docker](https://www.docker.com/)

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
             "phpstan/extension-installer": true
         },
         "platform": {
-            "php": "8.1"
+            "php": "8.2"
         },
         "preferred-install": {
             "*": "dist"


### PR DESCRIPTION
https://palantir.atlassian.net/browse/DEV-47

Update DDEV and CircleCI configs to use PHP 8.2

~Open question: Do we need to update the `composer.json` minimum PHP version and readme?~ Yes

## Testing

- Follow the steps in the readme to create a new project using this branch (update-php-8.2). For the Composer command use:

`composer create-project palantirnet/drupal-skeleton example dev-update-php-8.2 --no-interaction`