### PR TITLE
DEV-45: Prevent 404 error in the-build-installer by updating acquia memcache install task

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "palantirnet/the-build": "^4@beta"
     },
     "suggest": {
+        "acquia/memcache-settings": "If your acquia project uses Cloud Platform, add this package and update acquia settings file based on: https://docs.acquia.com/cloud-platform/performance/memcached/enable/#configuration-for-drupal-9-or-later .",
         "cweagans/composer-patches": "Try ^1.7. Apply patches to packages, especially Drupal.org contrib.",
         "drupal/admin_toolbar": "Transforms the default Drupal Toolbar into a drop-down menu.",
         "drupal/environment_indicator": "Adds a configurable color bar to each one of your environments to help identify which environment you are currently working in.",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "palantirnet/the-build": "dev-update-acquia-memcache"
     },
     "suggest": {
-        "acquia/memcache-settings": "If your acquia project uses Cloud Platform, add this package and update acquia settings file based on: https://docs.acquia.com/cloud-platform/performance/memcached/enable/#configuration-for-drupal-9-or-later .",
+        "acquia/memcache-settings": "If your acquia project uses Cloud Platform (and not Cloud Next), add this package and update acquia settings file based on: https://docs.acquia.com/cloud-platform/performance/memcached/enable/#configuration-for-drupal-9-or-later .",
         "cweagans/composer-patches": "Try ^1.7. Apply patches to packages, especially Drupal.org contrib.",
         "drupal/admin_toolbar": "Transforms the default Drupal Toolbar into a drop-down menu.",
         "drupal/environment_indicator": "Adds a configurable color bar to each one of your environments to help identify which environment you are currently working in.",

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,10 @@
         {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
+        },
+        {
+            "type": "git",
+            "url": "https://github.com/palantirnet/the-build"
         }
     ],
     "require": {
@@ -33,7 +37,7 @@
         "dmore/behat-chrome-extension": "^1.4",
         "drupal/core-dev": "^10",
         "drupal/drupal-extension": "^5@alpha",
-        "palantirnet/the-build": "^4@beta"
+        "palantirnet/the-build": "dev-update-acquia-memcache"
     },
     "suggest": {
         "acquia/memcache-settings": "If your acquia project uses Cloud Platform, add this package and update acquia settings file based on: https://docs.acquia.com/cloud-platform/performance/memcached/enable/#configuration-for-drupal-9-or-later .",

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,6 @@
         {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
-        },
-        {
-            "type": "git",
-            "url": "https://github.com/palantirnet/the-build"
         }
     ],
     "require": {
@@ -37,7 +33,7 @@
         "dmore/behat-chrome-extension": "^1.4",
         "drupal/core-dev": "^10",
         "drupal/drupal-extension": "^5@alpha",
-        "palantirnet/the-build": "dev-update-acquia-memcache"
+        "palantirnet/the-build": "^4@beta"
     },
     "suggest": {
         "acquia/memcache-settings": "If your acquia project uses Cloud Platform (and not Cloud Next), add this package and update acquia settings file based on: https://docs.acquia.com/cloud-platform/performance/memcached/enable/#configuration-for-drupal-9-or-later .",


### PR DESCRIPTION
User story: [DEV-45: 404 error on install in request for Acquia memcache config file](https://palantir.atlassian.net/browse/DEV-45)

### Description

This PR updates the process for adding memcache to an acquia project based on https://docs.acquia.com/cloud-platform/performance/memcached/enable/#configuration-for-drupal-9-or-later
* it points to a version of `the-build` with updated phing tasks during `the-build-installer`
* adds a suggestion package to `composer.json`

### Testing instructions

1. Pull this branch down
1. Run `composer create-project palantirnet/drupal-skeleton memcache dev-update-acquia-memcache-setup`
1. Edit `memcache/.ddev/config.yaml` to change the site name
1. Run `ddev start`
1. Run `ddev ssh`
1. Run the-build installer `vendor/bin/the-build-installer` and make sure you choose `acquia` as the host provider
- [ ] Observe the installer completes successfully 
- [ ] You should not have a failure because of a 404 error on an HTTP request
    ![image](https://github.com/palantirnet/drupal-skeleton/assets/3279883/bee1cb8a-d4b3-48f5-ba99-ef8022672884)
- [ ] There should be no `docroot/sites/default/cloud-memcache-d8+.php` file
    ![image](https://github.com/palantirnet/drupal-skeleton/assets/3279883/f168a67b-2bfa-44d7-afb1-6b8c21203192)
- [ ] The project's `composer.json` should include a `require` dependency: `drupal/memcache`
    ![image](https://github.com/palantirnet/drupal-skeleton/assets/3279883/ffb90697-05a5-4793-b0c9-af07a6c1c837)
- [ ] The project's `composer.json` should include a `suggest` dependency: `acquia/memcache-settings` with a link to the documentation and not to update settings for `Cloud Platform` (vs `Cloud Next`) projects.
    ![image](https://github.com/palantirnet/drupal-skeleton/assets/3279883/8ce8d9c7-3874-4d04-bd6a-70295673cb58)


### Remaining tasks

- [ ] Roll back change pointing to our branch for `the-build` in `composer.json`
