### PR TITLE
DEV-49: Fixing phpcs errors in FeatureContext.php.

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -1,23 +1,21 @@
 <?php
 
-use Drupal\DrupalExtension\Context\RawDrupalContext;
 use Behat\Behat\Context\SnippetAcceptingContext;
+use Drupal\DrupalExtension\Context\RawDrupalContext;
 
 /**
  * Defines application features from the specific context.
  */
-class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
-{
+class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext {
 
-    /**
-     * Initializes context.
-     *
-     * Every scenario gets its own context instance.
-     * You can also pass arbitrary arguments to the
-     * context constructor through behat.yml.
-     */
-    public function __construct()
-    {
-    }
+  /**
+   * Initializes context.
+   *
+   * Every scenario gets its own context instance.
+   * You can also pass arbitrary arguments to the
+   * context constructor through behat.yml.
+   */
+  public function __construct() {
+  }
 
 }


### PR DESCRIPTION
User story: [Add behat custom contexts to phpcs code reviews](https://palantir.atlassian.net/browse/DEV-49)

### Description
Fixes errors that were discovered when enabling phpcs to scan the features directory in the-build. 
Related PR: https://github.com/palantirnet/the-build/pull/233

### Testing instructions
1. Checkout the-build the the branch in the above PR and spin up "example"
1. Run vendor/bin/phpcs
1. Verify that there are no errors.
