### PR TITLE
DEV-53 - Add work around to ddev config to prevent git errors.

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -39,6 +39,8 @@ hooks:
     # Install the Node.js version specified in the project's .nvmrc file.
     # TODO: If your project does not use Node.js, you can remove this line.
     - exec: source "$NVM_DIR/nvm.sh" && nvm install --default
+    # Workaround for "dubious ownership" Git errors when using DDEV with VirtioFS.
+    - exec: git config --global --add safe.directory /var/www/html
     # By default, ddev provides a database called 'db'. If you need additional databases,
     # uncomment this section and change "default" to your database name.
 #    - exec: mysql -uroot -proot -e "CREATE DATABASE IF NOT EXISTS default; GRANT ALL ON default.* to 'db'@'%';"


### PR DESCRIPTION
User story: [DEV-53: Git "dubious ownership" errors inside DDEV with latest Docker Desktop](https://palantir.atlassian.net/browse/DEV-53)

### Description

Add work around in ddev config to deal with git "dubious ownership" errors inside ddev with latest docker desktop.

### Testing instructions

1. Restart ddev `ddev restart`
2. SSH into container `ddev ssh`
3. Check git status to verify that the error doesn't show `Git "dubious ownership"` `git status`
