### PR TITLE
Update to drush 12.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "drupal/devel": "^5",
         "drupal/workbench": "^1",
         "drupal/workbench_tabs": "^1",
-        "drush/drush": "^12"
+        "drush/drush": ">=11"
     },
     "require-dev": {
         "behat/behat": "^3.12",
@@ -55,7 +55,8 @@
             "drupal/core-composer-scaffold": true,
             "cweagans/composer-patches": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
-            "phpstan/extension-installer": true
+            "phpstan/extension-installer": true,
+            "php-http/discovery": true
         },
         "platform": {
             "php": "8.1"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "drupal/devel": "^5",
         "drupal/workbench": "^1",
         "drupal/workbench_tabs": "^1",
-        "drush/drush": "^11"
+        "drush/drush": "^12"
     },
     "require-dev": {
         "behat/behat": "^3.12",


### PR DESCRIPTION
User story: [DEV-66: Update the-build / drupal-skeleton to Drush 12](https://palantir.atlassian.net/browse/DEV-66)

### Description

Update to Drush 12 on the skeleton.

### Testing instructions

1. Run `composer install` locally
2. Run `composer show drush/drush` to verify that drush is at version 12.

