### PR TITLE
DEV-60: Remove use of assertion handler class

### DIFF
--- a/docroot/sites/default/settings.circleci.php
+++ b/docroot/sites/default/settings.circleci.php
@@ -18,14 +18,6 @@ $databases['default']['default'] = array(
 // Allow any host name.
 $settings['trusted_host_patterns'] = ['.*'];
 
-// Enable assertions.
-// @see http://php.net/assert
-// @see https://www.drupal.org/node/2492225
-use Drupal\Component\Assertion\Handle;
-
-assert_options(ASSERT_ACTIVE, TRUE);
-Handle::register();
-
 // Show all error messages, with backtrace information.
 $config['system.logging']['error_level'] = 'verbose';
 

--- a/docroot/sites/default/settings.ddev-overrides.php
+++ b/docroot/sites/default/settings.ddev-overrides.php
@@ -12,14 +12,6 @@ $settings['trusted_host_patterns'] = ['.*'];
 // better performance.
 $settings['class_loader_auto_detect'] = FALSE;
 
-// Enable assertions.
-// @see http://php.net/assert
-// @see https://www.drupal.org/node/2492225
-use Drupal\Component\Assertion\Handle;
-
-assert_options(ASSERT_ACTIVE, TRUE);
-Handle::register();
-
 // Enable local development services, including the null cache backend.
 $settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml';
 


### PR DESCRIPTION
User story: [DEV-60: Remove use of assertion handler class](https://palantir.atlassian.net/browse/DEV-60)

### Description

* Removes use of deprecated class from `settings.*.php` files.
* Removes calls to `assert_options()` from `settings.*.php` files.
* Assertions now rely on the PHP configuration having `zend.assertions` set to `1`

### Testing instructions

1. Follow the https://github.com/palantirnet/drupal-skeleton/blob/develop/README.md to setup a test site based on this branch. (Use `composer create-project palantirnet/drupal-skeleton example dev-DEV-60-remove-use-of-assertion-handler-class --no-interaction` instead of the `create-project` line in the readme.)
    Alternatively, make these same changes to an existing site's `settings.ddev-overrides.php`.
3. Change the following line in `/docroot/core/lib/Drupal/Core/Cache/Cache.php` to make the assertion fail:
    `assert(Inspector::assertAllStrings($cache_tags), 'Cache tags must be valid strings');`
    For example, change `$cache_tags` to `[1]` (an array of a single integer).
4. `ddev drush cr`
5. You should see `Fatal error: Uncaught AssertionError: Cache tags must be valid strings`
6. `ddev ssh`
7. `vi /etc/php/8.2/cli/conf.d/20-assert.ini`
8. Change the value of `zend.assertions` from `1` to `0` or `-1`.
9. `exit` and `ddev drush cr`
10. There should not be an error. This confirms that PHP assertions are being controlled by the PHP config and not Drupal's settings.
11. Revert the changes made during this test.

### Open questions

_Delete this section if there are no open questions._

* What questions are blocking this work?

### Remaining tasks

_Delete this section if there are no remaining tasks._

- [ ] Update the README
