### PR TITLE
DEV-50: Update DDEV minimum version to 1.23.4

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -34,7 +34,7 @@ xdebug_enabled: false
 hooks:
   pre-start:
     # Check the ddev version number; version 1.17 or newer is preferred.
-    - exec-host: if ! ddev --version | grep -E 'v1\.(2[3-9]|3\d\.[4-9]|\d\d)'; then echo ">>> PLEASE UPDATE DDEV TO VERSION 1.17 OR NEWER."; exit 1; fi
+    - exec-host: if ! ddev --version | grep -E 'v1\.(2[3-9]|3\d)\.([4-9]|\d\d)'; then echo ">>> PLEASE UPDATE DDEV TO VERSION 1.17 OR NEWER."; exit 1; fi
   post-start:
     # Workaround for "dubious ownership" Git errors when using DDEV with VirtioFS.
     - exec: git config --global --add safe.directory /var/www/html

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -34,7 +34,7 @@ xdebug_enabled: false
 hooks:
   pre-start:
     # Check the ddev version number; version 1.17 or newer is preferred.
-    - exec-host: if ! ddev --version | grep -E 'v1\.(1[7-9]|2\d)'; then echo ">>> PLEASE UPDATE DDEV TO VERSION 1.17 OR NEWER."; exit 1; fi
+    - exec-host: if ! ddev --version | grep -E 'v1\.(2[3-9]|3\d\.[4-9]|\d\d)'; then echo ">>> PLEASE UPDATE DDEV TO VERSION 1.17 OR NEWER."; exit 1; fi
   post-start:
     # Workaround for "dubious ownership" Git errors when using DDEV with VirtioFS.
     - exec: git config --global --add safe.directory /var/www/html

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -33,8 +33,8 @@ xdebug_enabled: false
 
 hooks:
   pre-start:
-    # Check the ddev version number; version 1.17 or newer is preferred.
-    - exec-host: if ! ddev --version | grep -E 'v1\.(2[3-9]|3\d)\.([4-9]|\d\d)'; then echo ">>> PLEASE UPDATE DDEV TO VERSION 1.23.4 OR NEWER."; exit 1; fi
+    # Check the ddev version number; version 1.23.4 or newer is required.
+    - exec-host: if ! ddev --version | grep -E 'v1\.(23\.[4-9]|23\.\d\d|2[4-9]|[3-9]\d)'; then echo ">>> PLEASE UPDATE DDEV TO VERSION 1.23.4 OR NEWER."; exit 1; fi
   post-start:
     # Workaround for "dubious ownership" Git errors when using DDEV with VirtioFS.
     - exec: git config --global --add safe.directory /var/www/html

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -34,7 +34,7 @@ xdebug_enabled: false
 hooks:
   pre-start:
     # Check the ddev version number; version 1.17 or newer is preferred.
-    - exec-host: if ! ddev --version | grep -E 'v1\.(2[3-9]|3\d)\.([4-9]|\d\d)'; then echo ">>> PLEASE UPDATE DDEV TO VERSION 1.17 OR NEWER."; exit 1; fi
+    - exec-host: if ! ddev --version | grep -E 'v1\.(2[3-9]|3\d)\.([4-9]|\d\d)'; then echo ">>> PLEASE UPDATE DDEV TO VERSION 1.23.4 OR NEWER."; exit 1; fi
   post-start:
     # Workaround for "dubious ownership" Git errors when using DDEV with VirtioFS.
     - exec: git config --global --add safe.directory /var/www/html

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -52,5 +52,5 @@ router_https_port: "443"
 provider: default
 use_dns_when_possible: true
 
-# TODO: Once everyone has updated to DDEV 1.23.4, change to nodejs_version: auto
-nodejs_version: 18
+# Use the NodeJS version from `.nvmrc` (or latest if none is defined).
+nodejs_version: auto


### PR DESCRIPTION
### Description

* Add an error message when not using DDEV 1.23.4 or higher.
* Automatically set the NodeJS version based on `.nvmrc` (requires DDEV 1.23.4 or higher).

### Testing instructions

- Use https://www.regextester.com/ to test the regex: `v1\.(23\.[4-9]|23\.\d\d|2[4-9]|[3-9]\d)`
- Try version numbers below and above 1.23.4, and confirm you get the expected result.
- Update `nodejs_version` to `auto` in an existing project that does not use `nvm` in DDEV.
- Verify the version from `.nvmrc` is used inside DDEV.

### Open questions

_Delete this section if there are no open questions._

* What questions are blocking this work?

### Remaining tasks

_Delete this section if there are no remaining tasks._

- [ ] Update the README
