### PR TITLE
Drupal 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     working_directory: ~/drupal-skeleton
     docker:
       - image: cimg/php:8.3-browsers
-      - image: cimg/mysql:5.7
+      - image: cimg/mysql:8.0
         command: --max_allowed_packet=16M
         environment:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -46,8 +46,7 @@ hooks:
 # This allows ddev to manage its own settings.ddev.php file.
 disable_settings_management: false
 
-# TODO: Update to drupal11 when the option is available.
-type: drupal10
+type: drupal11
 router_http_port: "80"
 router_https_port: "443"
 provider: default

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -34,7 +34,7 @@ xdebug_enabled: false
 hooks:
   pre-start:
     # Check the ddev version number; version 1.23.4 or newer is required.
-    - exec-host: if ! ddev --version | grep -E 'v1\.(24\.\d+|2[5-9]|[3-9]\d)'; then echo ">>> PLEASE UPDATE DDEV TO VERSION 1.24.0 OR NEWER."; exit 1; fi
+    - exec-host: if ! ddev --version | grep -E 'v1\.(2[4-9]|[3-9]\d)'; then echo ">>> PLEASE UPDATE DDEV TO VERSION 1.24.0 OR NEWER."; exit 1; fi
   post-start:
     # Workaround for "dubious ownership" Git errors when using DDEV with VirtioFS.
     - exec: git config --global --add safe.directory /var/www/html

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -7,14 +7,14 @@ name: drupal-skeleton
 
 # TODO: If the project uses Acquia hosting, use these settings.
 docroot: docroot
-mysql_version: "5.7"
+mysql_version: "8.0"
 webserver_type: apache-fpm
 
 # TODO: If the project uses Pantheon or Platform.sh hosting, remove the Acquia settings
 # and use these settings instead.
 #docroot: web
 #webserver_type: nginx-fpm
-#mariadb_version: "10.3"
+#mariadb_version: "10.6"
 
 # TODO: Make sure this PHP version matches the project's hosting environment.
 php_version: "8.2"
@@ -46,6 +46,7 @@ hooks:
 # This allows ddev to manage its own settings.ddev.php file.
 disable_settings_management: false
 
+# TODO: Update to drupal11 when the option is available.
 type: drupal10
 router_http_port: "80"
 router_https_port: "443"

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -34,7 +34,7 @@ xdebug_enabled: false
 hooks:
   pre-start:
     # Check the ddev version number; version 1.23.4 or newer is required.
-    - exec-host: if ! ddev --version | grep -E 'v1\.(23\.[4-9]|23\.\d\d|2[4-9]|[3-9]\d)'; then echo ">>> PLEASE UPDATE DDEV TO VERSION 1.23.4 OR NEWER."; exit 1; fi
+    - exec-host: if ! ddev --version | grep -E 'v1\.(24\.\d+|2[5-9]|[3-9]\d)'; then echo ">>> PLEASE UPDATE DDEV TO VERSION 1.24.0 OR NEWER."; exit 1; fi
   post-start:
     # Workaround for "dubious ownership" Git errors when using DDEV with VirtioFS.
     - exec: git config --global --add safe.directory /var/www/html

--- a/README.dist.md
+++ b/README.dist.md
@@ -83,4 +83,4 @@ General:
 * [Drupal Development](docs/general/drupal_development.md)
 
 ----
-Copyright 2022 Palantir.net, Inc.
+Copyright 2025 Palantir.net, Inc.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The development dependencies are:
 * [DDev Local](https://ddev.com/ddev-local/)
 
 On Macs, Docker and ddev can be installed with [homebrew](https://brew.sh/):
+
   * `brew install docker --cask`
   * `brew install ddev`
 
@@ -33,7 +34,7 @@ Enter a short name for your project [example] :
 
 ### Steps
 
-1. Create a new Drupal 10 project called "example" based on this template:
+1. Create a new Drupal project called "example" based on this template:
 
     ```
     composer create-project palantirnet/drupal-skeleton example dev-develop --no-interaction
@@ -238,4 +239,4 @@ In Drupal development, all (or most) Drupal configuration should be exported and
 * Site build and install process: [palantirnet/the-build](https://github.com/palantirnet/the-build)
 
 ----
-Copyright 2016 - 2021 Palantir.net, Inc.
+Copyright 2016 - 2025 Palantir.net, Inc.

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,8 @@
             "cweagans/composer-patches": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "phpstan/extension-installer": true,
-            "php-http/discovery": true
+            "php-http/discovery": true,
+            "tbachert/spi": false
         },
         "platform": {
             "php": "8.3"

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     "conflict": {
         "drupal/drupal": "*"
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true,
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "dmore/behat-chrome-extension": "^1.4",
         "drupal/core-dev": "^11",
         "drupal/drupal-extension": "^5",
-        "palantirnet/the-build": "^4"
+        "palantirnet/the-build": "dev-drupal11"
     },
     "suggest": {
         "acquia/memcache-settings": "If your acquia project uses Cloud Platform (and not Cloud Next), add this package and update acquia settings file based on: https://docs.acquia.com/cloud-platform/performance/memcached/enable/#configuration-for-drupal-9-or-later .",

--- a/composer.json
+++ b/composer.json
@@ -18,22 +18,19 @@
     "require": {
         "composer/installers": "^2.0",
         "drupal/admin_toolbar": "^3",
-        "drupal/config_ignore": "2.x-dev",
-        "drupal/config_split": "^1",
-        "drupal/core-composer-scaffold": "^10",
-        "drupal/core-recommended": "^10",
+        "drupal/config_ignore": "^3",
+        "drupal/config_split": "^2",
+        "drupal/core-composer-scaffold": "^11",
+        "drupal/core-recommended": "^11",
         "drupal/devel": "^5",
-        "drupal/workbench": "^1",
-        "drupal/workbench_tabs": "^1",
-        "drush/drush": ">=11"
+        "drush/drush": "^13"
     },
     "require-dev": {
         "behat/behat": "^3.12",
-        "behat/mink-goutte-driver": "^2.0",
         "dmore/behat-chrome-extension": "^1.4",
-        "drupal/core-dev": "^10",
-        "drupal/drupal-extension": "^5@alpha",
-        "palantirnet/the-build": "^4@beta"
+        "drupal/core-dev": "^11",
+        "drupal/drupal-extension": "^5",
+        "palantirnet/the-build": "^4"
     },
     "suggest": {
         "acquia/memcache-settings": "If your acquia project uses Cloud Platform (and not Cloud Next), add this package and update acquia settings file based on: https://docs.acquia.com/cloud-platform/performance/memcached/enable/#configuration-for-drupal-9-or-later .",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "dmore/behat-chrome-extension": "^1.4",
         "drupal/core-dev": "^11",
         "drupal/drupal-extension": "^5",
-        "palantirnet/the-build": "dev-drupal11"
+        "palantirnet/the-build": "^4.3"
     },
     "suggest": {
         "acquia/memcache-settings": "If your acquia project uses Cloud Platform (and not Cloud Next), add this package and update acquia settings file based on: https://docs.acquia.com/cloud-platform/performance/memcached/enable/#configuration-for-drupal-9-or-later .",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "palantirnet/drupal-skeleton",
-    "description": "A Drupal 10 project template.",
+    "description": "A Drupal project template.",
     "type": "project",
     "license": "proprietary",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "drupal/core-composer-scaffold": "^11",
         "drupal/core-recommended": "^11",
         "drupal/devel": "^5",
+        "drupal/workbench": "^1.5",
         "drupal/workbench_tabs": "^1.8",
         "drush/drush": "^13"
     },

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "drupal/core-composer-scaffold": "^11",
         "drupal/core-recommended": "^11",
         "drupal/devel": "^5",
+        "drupal/workbench_tabs": "^1.8",
         "drush/drush": "^13"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     "conflict": {
         "drupal/drupal": "*"
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
         "allow-plugins": {

--- a/docs/general/drupal_development.md
+++ b/docs/general/drupal_development.md
@@ -1,8 +1,6 @@
 # Drupal Development
 
-
-
-From outside the VM, you can find the files for:
+From outside the ddev environment, you can find the files for:
 
 * The custom theme at `web/themes/custom/`
 * Custom modules at `web/modules/custom/`
@@ -14,7 +12,7 @@ From outside the VM, you can find the files for:
 * Template files for Drupal `settings.php` at `.the-build/drupal/settings.php` and `.the-build/drupal/settings.<hosting-platform>.php`
 * Behat tests at `features/`
 
-From within the VM:
+From within ddev:
 
 * Run `drush` commands from anywhere within the repository
 * Add a module using `composer require drupal/new_module`
@@ -26,17 +24,17 @@ From within the VM:
 
 ## The Drupal root
 
-This project uses [Composer Installers](https://github.com/composer/installers), [drupal-scaffold](https://github.com/drupal-composer/drupal-scaffold), and [palantirnet/the-build](https://github.com/palantirnet/the-build) to assemble our Drupal root in `web`. Dig into `web` to find the both contrib Drupal code (installed by composer) and custom Drupal code (included in the git repository).
+This project uses [Composer Installers](https://github.com/composer/installers), [drupal-scaffold](https://github.com/drupal-composer/drupal-scaffold), and [palantirnet/the-build](https://github.com/palantirnet/the-build) to assemble our Drupal root in `docroot` (Acquia projects) or `web` (other Drupal hosts). Dig into the Drupal root to find the both contrib Drupal code (installed by composer) and custom Drupal code (included in the git repository).
 
 ## Add modules
 
-Drupal contrib dependencies are managed with composer, and are not checked directly into this repository. To add a module, ssh into your VM, then:
+Drupal contrib dependencies are managed with composer, and are not checked directly into this repository. To add a module, you can:
 
 1. Download the module with composer: `composer require drupal/bad_judgement:~8.1`
-2. Enable the module with drush: `drush en bad_judgement`
+2. Enable the module with drush: `ddev drush en bad_judgement`
 3. Visit your local site and configure the module as necessary
-4. Export the config with the module enabled: `drush config-export`
-5. Commit the changes to `composer.json`, `composer.lock`, and `conf/drupal/config/*`.
+4. Export the config with the module enabled: `ddev drush config-export`
+5. Commit the changes to `composer.json`, `composer.lock`, and `config/*`.
 
 Note that the module code itself will be excluded by the project's `.gitignore`; Composer will manage downloading and installing the module code for other developers when they run `composer install`.
 
@@ -56,7 +54,7 @@ Existing splits are defined by a YML file at `config/sites/default/config_split.
 #### Exporting shared configuration for all environments
 
 1. Make any changes in the Drupal UI or via drush as usual
-1. Use drush to export the shared configuration to `config/sites/default`
+2. Use drush to export the shared configuration to `config/sites/default`
 
 #### Exporting environment-specific config
 
@@ -87,15 +85,7 @@ Existing splits are defined by a YML file at `config/sites/default/config_split.
 
 ### Setting specific config variables
 
-Some specific config variables are managed on a per-environment basis using `settings.build.php` templating, which is part of the `phing build` step. See:
-
-* `.the-build/drupal/settings.build.php`: The template used for the VM and CircleCI environments
-* `.the-build/drupal/settings.build-acquia.php`: The template used for the Acquia environment
-* `.the-build/build.yml`: Properties used by `phing` targets
-* `.the-build/build.circle.yml`: Property overrides used when running `phing` commands on CircleCI
-* `.the-build/build.acquia.yml`: Property overrides used when running the `phing` command to deploy to Acquia
-
-When you make changes to these files, you will generally need to run `phing build` in order to see your changes.
+Some specific Drupal configuration is managed on a per-environment basis using different `settings.*.php` files, which are located in the Drupal sites directory (e.g. `docroot/sites/default/`). You can edit these files directly, with the exception of `settings.ddev.php`.
 
 ### Test Drupal
 
@@ -114,4 +104,4 @@ If you'd like to handle your custom module's linting independently, add your mod
 Note: There is [some default configuration for eslint](https://github.com/palantirnet/the-build/pull/223/files#diff-339072f52845d316656969cbac2815305c0ccea0ce9de789ba73d78849336067)) that you can override in your project configuration for `the-build` 
 
 ----
-Copyright 2023 Palantir.net, Inc.
+Copyright 2023-2025 Palantir.net, Inc.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,16 @@
   "version": "0.0.0",
   "devDependencies": {
     "eslint": "8.39.0",
-    "eslint-config-drupal": "5.0.2"
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-drupal": "5.0.2",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-jsx-a11y": "^6.9.0",
+    "eslint-plugin-prettier": "^5.2.1",
+    "eslint-plugin-react": "^7.35.0",
+    "eslint-plugin-storybook": "^0.8.0",
+    "eslint-plugin-yml": "^1.14.0",
+    "prettier": "^3.3.3",
+    "typescript": "^5.5.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,12 +8,8 @@
     "eslint-config-drupal": "^5.0.2",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.29.1",
-    "eslint-plugin-jsx-a11y": "^6.9.0",
     "eslint-plugin-prettier": "^5.2.1",
-    "eslint-plugin-react": "^7.35.0",
-    "eslint-plugin-storybook": "^0.8.0",
     "eslint-plugin-yml": "^1.14.0",
-    "prettier": "^3.3.3",
-    "typescript": "^5.5.4"
+    "prettier": "^3.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "palantirnet--drupal-skeleton",
-  "description": "A Drupal 8 project template.",
+  "description": "A Drupal 11 project template.",
   "version": "0.0.0",
   "devDependencies": {
-    "eslint": "8.39.0",
+    "eslint": "^8.39.0",
     "eslint-config-airbnb-base": "^15.0.0",
-    "eslint-config-drupal": "5.0.2",
+    "eslint-config-drupal": "^5.0.2",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jsx-a11y": "^6.9.0",


### PR DESCRIPTION
User story: [DEV-67: Update drupal-skeleton to Drupal 11](https://palantir.atlassian.net/browse/DEV-67)

### Description

Requires https://github.com/palantirnet/drupal-skeleton/pull/156 and https://github.com/palantirnet/the-build/pull/236

- Updates Composer dependencies to be compatible with Drupal 11.
- ~`minimum-stability` has been set to `dev` until a release of `drupal-driver` supports Symfony 7.~
- ~Removes Workbench and Workbench Tabs until D11-compatible versions are available.~
    - https://www.drupal.org/project/workbench/issues/3435729
    - https://www.drupal.org/project/workbench_tabs/issues/3435734

### Testing instructions

- `composer create-project palantirnet/drupal-skeleton example dev-drupal11 --no-interaction --no-install`
- `composer require --dev palantirnet/the-build:dev-drupal11`
- Continue with the drupal-skeleton getting started instructions in the readme, starting with step 2.

### Open questions

_Delete this section if there are no open questions._

* What questions are blocking this work?

### Remaining tasks

_Delete this section if there are no remaining tasks._

- [x] Update the README
- [x] Todo: Once Workbench and Workbench Tabs have Drupal 11 compatibility, add them back.
