### PR TITLE
DEV-35 - Watching a port for chrome conflicts with other sites.

### DIFF
--- a/.ddev/docker-compose.chrome.yaml
+++ b/.ddev/docker-compose.chrome.yaml
@@ -1,5 +1,4 @@
 # This was taken from https://github.com/drud/ddev-contrib/tree/master/docker-compose-services/headless-chrome.
-version: '3.6'
 services:
     chrome:
         image:  isholgueras/chrome-headless:latest

--- a/.ddev/docker-compose.chrome.yaml
+++ b/.ddev/docker-compose.chrome.yaml
@@ -15,7 +15,7 @@ services:
             - "ddev-router:${DDEV_HOSTNAME}"
         cap_add:
             - SYS_ADMIN
-        ports:
+        #ports:
         # Exposing this port allows you to visit 127.0.0.1:9222 to see what Headless Chrome doing without
         # any additional configuration; However, you can only have one project using this port at a time.
-            - '9222:9222'
+        #    - '9222:9222'

--- a/.ddev/docker-compose.solr.yaml
+++ b/.ddev/docker-compose.solr.yaml
@@ -21,8 +21,6 @@
 #   accessed at the URL: http://solr:8983/solr/dev (inside web container)
 #   or at http://myproject.ddev.site:8983/solr/dev (on the host)
 
-version: '3.6'
-
 services:
   solr:
     # Name of container using standard ddev convention


### PR DESCRIPTION
User story: [DEV-35: Improved chrome testing config](https://palantir.atlassian.net/browse/DEV-35)

### Description

Don't expose a port for chrome testing because it interferes with starting up other sites.

### Testing instructions

1. Run `ddev start`
2. Verify that you can start multiple projects if this config is in those projects as well.
